### PR TITLE
[Refactor] 구독/통계 빈 화면 목데이터 프리뷰 및 스켈레톤 공통화

### DIFF
--- a/app/(home)/_components/home-page-content.tsx
+++ b/app/(home)/_components/home-page-content.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Suspense } from "react";
+import { cn } from "@/lib/utils";
 
 import HomePageSkeleton from "./home-page-skeleton";
 import HomeSummaryCard from "./home-summary-card";
@@ -34,7 +35,12 @@ function HomeMain({
   );
 
   return (
-    <>
+    <div
+      className={cn(
+        !hasSubscription &&
+          "flex min-h-[calc(100dvh-56px-70px)] flex-col overflow-hidden"
+      )}
+    >
       <section className="mb-4 grid grid-cols-[1fr_100px] items-center justify-between bg-white px-6 py-5">
         <HomeSummaryCard
           hasSubscription={hasSubscription}
@@ -48,7 +54,7 @@ function HomeMain({
         thisMonthTotal={thisMonthTotal}
         isLoggedIn={isLoggedIn}
       />
-    </>
+    </div>
   );
 }
 

--- a/app/(home)/_components/home-page-skeleton.tsx
+++ b/app/(home)/_components/home-page-skeleton.tsx
@@ -1,22 +1,24 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
 export default function HomePageSkeleton() {
   return (
-    <div className="animate-pulse">
+    <div>
       <section className="mb-4 grid grid-cols-[1fr_100px] items-center justify-between bg-white px-6 py-5">
         <div className="flex flex-col gap-3">
-          <div className="h-5 w-40 rounded bg-gray-100" />
-          <div className="h-8 w-28 rounded bg-gray-100" />
+          <Skeleton className="h-5 w-40" />
+          <Skeleton className="h-8 w-28" />
         </div>
-        <div className="h-[100px] w-[100px] rounded-lg bg-gray-100" />
+        <Skeleton className="h-[100px] w-[100px] rounded-lg" />
       </section>
       <section className="border-t-16 border-t-gray-100 bg-white pt-10">
         <div className="flex flex-col gap-4 px-6">
           <div className="flex justify-between">
-            <div className="h-6 w-36 rounded bg-gray-100" />
-            <div className="h-6 w-20 rounded bg-gray-100" />
+            <Skeleton className="h-6 w-36" />
+            <Skeleton className="h-6 w-20" />
           </div>
           <div className="flex flex-col gap-3">
-            <div className="h-[72px] w-full rounded-lg bg-gray-100" />
-            <div className="h-[72px] w-full rounded-lg bg-gray-100" />
+            <Skeleton className="h-[72px] w-full rounded-lg" />
+            <Skeleton className="h-[72px] w-full rounded-lg" />
           </div>
         </div>
       </section>

--- a/app/(home)/_components/home-subscription-section.tsx
+++ b/app/(home)/_components/home-subscription-section.tsx
@@ -1,8 +1,14 @@
+import type { ComponentProps } from "react";
 import Link from "next/link";
 import SubscriptionList from "@/app/components/subscription-list";
 import type { SubscriptableBrandType } from "@/app/utils/brand/type";
+import {
+  EMPTY_STATE_PREVIEW_SUBSCRIPTIONS,
+  EMPTY_STATE_PREVIEW_SUBSCRIPTION_TOTAL,
+} from "@/app/utils/empty-state-preview";
 import type { Tables } from "@/types/supabase.types";
 import BottomCTA from "@/app/components/bottom-cta";
+import { cn } from "@/lib/utils";
 
 interface Props {
   hasSubscription: boolean;
@@ -12,6 +18,20 @@ interface Props {
   isLoggedIn: boolean;
 }
 
+type SubscriptionListItemProps = ComponentProps<typeof SubscriptionList>;
+type DisplaySubscriptionItem = {
+  key: string;
+  href?: string;
+} & Pick<
+  SubscriptionListItemProps,
+  | "brandType"
+  | "price"
+  | "billingCycle"
+  | "group"
+  | "groupCount"
+  | "isFreeTrial"
+>;
+
 export default function HomeSubscriptionSection({
   hasSubscription,
   subscriptions,
@@ -19,35 +39,81 @@ export default function HomeSubscriptionSection({
   thisMonthTotal,
   isLoggedIn,
 }: Props) {
+  const displaySubscriptions: DisplaySubscriptionItem[] = hasSubscription
+    ? subscriptions.map((item) => ({
+        key: item.id,
+        href: `/subscription/${item.id}`,
+        brandType: item.service as SubscriptableBrandType,
+        price: item.total_amount / Math.max(item.member_count, 1),
+        billingCycle: item.billing_cycle,
+        group: item.subscription_mode === "group",
+        groupCount: item.member_count,
+        isFreeTrial: item.payment_type === "trial",
+      }))
+    : EMPTY_STATE_PREVIEW_SUBSCRIPTIONS.map((item, index) => ({
+        key: `preview-${index}`,
+        ...item,
+      }));
+
+  const displaySubscriptionCount = hasSubscription
+    ? subscriptionCount
+    : EMPTY_STATE_PREVIEW_SUBSCRIPTIONS.length;
+  const displayThisMonthTotal = hasSubscription
+    ? thisMonthTotal
+    : EMPTY_STATE_PREVIEW_SUBSCRIPTION_TOTAL;
+
   return (
-    <section className="pt-10 bg-white border-t-gray-100 border-t-16">
-      <div className="relative flex flex-col justify-start items-start gap-4  min-h-[calc(100vh_-_56px_-_148px_-_16px_-_148px_-_70px)]">
-        <div className="px-6 w-full flex justify-between items-center">
+    <section
+      className={cn(
+        "pt-10 bg-white border-t-gray-100 border-t-16",
+        !hasSubscription && "flex min-h-0 flex-1 flex-col overflow-hidden"
+      )}
+    >
+      <div
+        className={cn(
+          "relative flex flex-col justify-start items-start gap-4 min-h-[calc(100vh_-_56px_-_148px_-_16px_-_148px_-_70px)]",
+          !hasSubscription && "min-h-0 flex-1 overflow-hidden"
+        )}
+      >
+        <div
+          className="px-6 w-full flex justify-between items-center"
+          aria-hidden={!hasSubscription}
+        >
           <h6 className="title-md text-black">
             나의 구독{" "}
-            <span className="text-brand-primary">총 {subscriptionCount}개</span>
+            <span className="text-brand-primary">
+              총 {displaySubscriptionCount}개
+            </span>
           </h6>
-          <h6 className="header-md">{thisMonthTotal.toLocaleString()}원</h6>
+          <h6 className="header-md">
+            {displayThisMonthTotal.toLocaleString()}원
+          </h6>
         </div>
-        <ul className="px-6 w-full">
-          {subscriptions.map((item) => (
-            <li key={item.id}>
+        <ul
+          className={cn(
+            "px-6 w-full",
+            !hasSubscription && "flex-1 min-h-0 overflow-hidden"
+          )}
+          aria-hidden={!hasSubscription}
+        >
+          {displaySubscriptions.map((item) => (
+            <li key={item.key}>
               <SubscriptionList
-                href={`/subscription/${item.id}`}
-                brandType={item.service as SubscriptableBrandType}
-                price={item.total_amount / Math.max(item.member_count, 1)}
-                billingCycle={item.billing_cycle}
-                group={item.subscription_mode === "group"}
-                groupCount={item.member_count}
-                isFreeTrial={item.payment_type === "trial"}
+                href={item.href}
+                brandType={item.brandType}
+                price={item.price}
+                billingCycle={item.billingCycle}
+                group={item.group}
+                groupCount={item.groupCount}
+                isFreeTrial={item.isFreeTrial}
               />
             </li>
           ))}
         </ul>
         {!hasSubscription && (
-          <div className="absolute w-full h-full flex flex-col items-center justify-center gap-4 text-center bg-linear-to-bl from-white/50 to-white backdrop-blur-[1.5px]">
+          <div className="absolute inset-0 flex flex-col gap-2 items-center justify-center text-center bg-linear-to-bl from-white/50 to-white backdrop-blur-[1.5px]">
             <h6 className="title-md text-black">구독 서비스를 추가 하세요</h6>
-            <p className="body-md text-gray-300">
+            <p className="body-lg text-gray-300">
               내가 사용하는 구독을 추가하고
               <br />
               소비를 절약해보세요
@@ -65,7 +131,7 @@ export default function HomeSubscriptionSection({
             href="/login?redirect=/subscription/add"
             className="btn btn-primary btn-lg"
           >
-            로그인하고 구독 추가하기
+            로그인 하기
           </Link>
         )}
       </BottomCTA>

--- a/app/(home)/_components/home-summary-skeleton.tsx
+++ b/app/(home)/_components/home-summary-skeleton.tsx
@@ -16,12 +16,12 @@ export default function HomeSummarySkeleton({ type }: Props) {
     <>
       <div className="flex flex-col gap-4">
         <div className="title">
-          <Skeleton className="h-8 w-24 rounded-md bg-gray-100" />
+          <Skeleton className="h-8 w-24 rounded-md" />
           <div className="flex items-center gap-2 mt-1">
-            <Skeleton className="h-8 w-28 rounded-md bg-gray-100" />
-            <Skeleton className="h-8 w-16 rounded-md bg-gray-100" />
+            <Skeleton className="h-8 w-28 rounded-md" />
+            <Skeleton className="h-8 w-16 rounded-md" />
             {isSaved && (
-              <Skeleton className="h-8 w-20 rounded-md bg-gray-100" />
+              <Skeleton className="h-8 w-20 rounded-md" />
             )}
           </div>
         </div>
@@ -35,7 +35,7 @@ export default function HomeSummarySkeleton({ type }: Props) {
         </Link>
       </div>
       <div>
-        <Skeleton className="w-[100px] h-[100px] rounded-2xl bg-gray-100" />
+        <Skeleton className="w-[100px] h-[100px] rounded-2xl" />
       </div>
     </>
   );

--- a/app/components/bottom-cta/bottom-cta.tsx
+++ b/app/components/bottom-cta/bottom-cta.tsx
@@ -3,25 +3,32 @@
 import { cn } from "@/lib/utils";
 
 export const BOTTOM_CTA_HEIGHT = 88; // py-4(32px) + 버튼 h-14(56px)
+export const BOTTOM_NAV_HEIGHT = 60;
 
 interface Props {
   children: React.ReactNode;
   className?: string;
   hasBottomNav?: boolean;
+  reserveSpace?: boolean;
 }
 
 export default function BottomCTA({
   children,
   className,
   hasBottomNav = false,
+  // reserveSpace = true,
 }: Props) {
   return (
     <>
-      <div style={{ height: BOTTOM_CTA_HEIGHT }} aria-hidden />
+      {/* {reserveSpace ? (
+        <div style={{ height: BOTTOM_CTA_HEIGHT }} aria-hidden />
+      ) : null} */}
       <div
         className={cn(
-          "fixed bottom-0 left-0 right-0 bg-white px-6 py-4 max-w-(--max-width) mx-auto",
-          hasBottomNav ? "pb-[calc(1rem+60px)]" : "",
+          "fixed z-99 left-0 right-0 bg-white px-6 py-4 max-w-(--max-width) mx-auto",
+          hasBottomNav
+            ? "bottom-[calc(60px+env(safe-area-inset-bottom))]"
+            : "bottom-0",
           className ?? ""
         )}
       >

--- a/app/components/bottom-cta/index.tsx
+++ b/app/components/bottom-cta/index.tsx
@@ -1,1 +1,1 @@
-export { default, BOTTOM_CTA_HEIGHT } from "./bottom-cta";
+export { default, BOTTOM_CTA_HEIGHT, BOTTOM_NAV_HEIGHT } from "./bottom-cta";

--- a/app/components/bottom-nav/bottom-nav.tsx
+++ b/app/components/bottom-nav/bottom-nav.tsx
@@ -33,7 +33,7 @@ export default function BottomNav() {
       <div aria-hidden="true" className={BOTTOM_NAV_HEIGHT_CLASS} />
       <nav
         className={cn(
-          "fixed bottom-0 left-1/2 -translate-x-1/2 z-10 flex w-full items-center justify-around rounded-t-lg bg-white border border-gray-50",
+          "fixed bottom-0 left-1/2 -translate-x-1/2 z-999 flex w-full items-center justify-around rounded-t-lg bg-white border border-gray-50",
           "max-w-(--max-width) mx-auto",
           BOTTOM_NAV_HEIGHT_CLASS,
           BOTTOM_NAV_SAFE_AREA_CLASS

--- a/app/components/subscription-list/subscription-list.tsx
+++ b/app/components/subscription-list/subscription-list.tsx
@@ -37,14 +37,8 @@ export default function SubscriptionList({
   groupCount,
   isFreeTrial = false,
 }: Props) {
-  return (
-    <Link
-      href={href ?? ""}
-      className={cn(
-        "w-full grid grid-cols-[1fr_auto_auto] items-center gap-4 py-4 bg-white",
-        href ? "cursor-pointer" : "cursor-default"
-      )}
-    >
+  const content = (
+    <>
       <div className="flex items-start gap-3">
         <BrandBox brandType={brandType} size="sm" />
         <div>
@@ -73,6 +67,26 @@ export default function SubscriptionList({
           className="w-5 h-5 text-gray-300"
         />
       )}
+    </>
+  );
+
+  const className = cn(
+    "w-full grid grid-cols-[1fr_auto_auto] items-center gap-4 py-4 bg-white",
+    href ? "cursor-pointer" : "cursor-default"
+  );
+
+  if (!href) {
+    return <div className={className}>{content}</div>;
+  }
+
+  return (
+    <Link
+      href={href}
+      className={cn(
+        className
+      )}
+    >
+      {content}
     </Link>
   );
 }

--- a/app/notifications/_components/notifications-skeleton.tsx
+++ b/app/notifications/_components/notifications-skeleton.tsx
@@ -1,15 +1,16 @@
 import Header from "@/app/components/header";
+import { Skeleton } from "@/components/ui/skeleton";
 
 export default function NotificationsSkeleton() {
   return (
     <main className="relative w-full min-h-screen flex flex-col items-start justify-start">
       <Header variant="back" title="알림" />
-      <div className="w-full mt-5 px-6 flex flex-col gap-10 animate-pulse">
+      <div className="w-full mt-5 px-6 flex flex-col gap-10">
         <div className="flex flex-col gap-5">
-          <div className="h-5 w-12 bg-gray-100 rounded" />
+          <Skeleton className="h-5 w-12" />
           <div className="flex flex-col gap-4">
             {[1, 2, 3].map((i) => (
-              <div key={i} className="h-16 w-full bg-gray-100 rounded-lg" />
+              <Skeleton key={i} className="h-16 w-full rounded-lg" />
             ))}
           </div>
         </div>

--- a/app/notifications/settings/_components/notification-settings-skeleton.tsx
+++ b/app/notifications/settings/_components/notification-settings-skeleton.tsx
@@ -11,16 +11,16 @@ export default function NotificationSettingsSkeleton() {
             className="w-full flex items-center justify-between py-4"
           >
             <div className="flex flex-col gap-2">
-              <Skeleton className="h-5 w-24 rounded-md bg-brand-primary/20" />
-              <Skeleton className="h-4 w-48 rounded-md bg-brand-primary/20" />
+              <Skeleton className="h-5 w-24 rounded-md" />
+              <Skeleton className="h-4 w-48 rounded-md" />
             </div>
-            <Skeleton className="h-6 w-11 rounded-full shrink-0  bg-brand-primary/20" />
+            <Skeleton className="h-6 w-11 rounded-full shrink-0" />
           </div>
         ))}
       </div>
 
       <BottomCTA>
-        <Skeleton className="h-14 w-full rounded-lg  bg-brand-primary/20" />
+        <Skeleton className="h-14 w-full rounded-lg" />
       </BottomCTA>
     </>
   );

--- a/app/statistics/_components/analysis-summary/analysis-summary.tsx
+++ b/app/statistics/_components/analysis-summary/analysis-summary.tsx
@@ -35,14 +35,14 @@ export default function AnalysisSummary({
 
   return (
     <div className="w-full px-5 py-6 bg-white animate-in fade-in slide-in-from-bottom-4 duration-700">
-      <div className="mb-8">
+      {/* <div className="mb-8">
         <h2 className="title-md text-brand-primary font-bold">
           AI 디톡이<span className="text-gray-900">의 소비분석 요약</span>
         </h2>
         <p className="body-md text-gray-400 mt-1">
           AI가 분석한 정보로 일부는 실제와 다를 수 있어요.
         </p>
-      </div>
+      </div> */}
 
       <div className="flex flex-col gap-12">
         {items.map(({ label, data: analysisData }) => {
@@ -50,21 +50,25 @@ export default function AnalysisSummary({
           return (
             <section
               key={label}
-              className="flex flex-col gap-6 border-b border-gray-100 pb-10 last:border-0 last:pb-0"
+              className="flex flex-col gap-10 border-b border-gray-100 pb-10 last:border-0 last:pb-0"
             >
-              <p className="body-md font-medium text-gray-500 leading-snug">
+              {/* <p className="body-md font-medium text-gray-500 leading-snug">
                 {label}
-              </p>
+              </p> */}
               <div className="flex flex-col gap-1">
-                <h3 className="title-md font-bold text-brand-primary leading-tight">
+                <h2 className="title-md text-brand-primary font-bold">
+                  AI 디톡이
+                  <span className="text-gray-900">의 소비분석 요약</span>
+                </h2>
+                {/* <h3 className="title-md font-bold text-brand-primary leading-tight">
                   {analysisData.title}
-                </h3>
-                <p className="body-md text-gray-700 leading-relaxed whitespace-pre-line">
+                </h3> */}
+                <p className="body-md text-gray-200 leading-relaxed whitespace-pre-line">
                   {analysisData.description}
                 </p>
               </div>
 
-              <div className="flex flex-col gap-4">
+              <div className="flex flex-col gap-10">
                 {analysisItems.map((item, index) => {
                   const brandType = toBrandType(item.brand);
                   const displayBrand =
@@ -87,8 +91,8 @@ export default function AnalysisSummary({
                         </div>
                       </div>
 
-                      <div className="w-full bg-gray-50 rounded-2xl py-8 flex flex-col items-center justify-center gap-4 border border-gray-100">
-                        <BrandBox brandType={displayBrand} size="lg" />
+                      <div className="w-full bg-gray-50 rounded-2xl py-6 flex flex-col items-center justify-center gap-4 border border-gray-100">
+                        <BrandBox brandType={displayBrand} size="sm" />
 
                         {(isSubscribe || isCancel) && (
                           <div

--- a/app/statistics/_components/comparison-chart/comparison-chart.tsx
+++ b/app/statistics/_components/comparison-chart/comparison-chart.tsx
@@ -24,23 +24,40 @@ export default function ComparisonChart({
   isLoading = false,
 }: Props) {
   if (isLoading) {
+    const skeletonBars = [
+      {
+        labelClassName: "h-5 w-16",
+        barClassName: "h-28 w-[30px] rounded-t-[4px] rounded-b-none",
+      },
+      {
+        labelClassName: "h-5 w-20",
+        barClassName: "h-36 w-[30px] rounded-t-[4px] rounded-b-none",
+      },
+    ];
+
     return (
-      <div className="flex flex-col gap-4">
-        <div className="mx-6 py-6 bg-gray-50 rounded-lg h-56">
-          <div className="h-full w-full flex flex-col justify-end gap-4 px-6 pb-2">
-            <div className="flex items-end justify-between gap-6">
-              <Skeleton className="h-28 w-12 bg-gray-200/70" />
-              <Skeleton className="h-20 w-12 bg-gray-200/70" />
-              <Skeleton className="h-32 w-12 bg-gray-200/70" />
-              <Skeleton className="h-24 w-12 bg-gray-200/70" />
-            </div>
-            <div className="flex items-center justify-between">
-              <Skeleton className="h-4 w-16 bg-gray-200/70" />
-              <Skeleton className="h-4 w-16 bg-gray-200/70" />
-            </div>
+      <div className="mx-6">
+        <div className="h-56 rounded-lg bg-gray-50 px-6 pt-5">
+          <div className="grid h-full grid-cols-2 gap-6 pb-2">
+            {skeletonBars.map((bar, index) => (
+              <div
+                key={index}
+                className="flex h-full flex-col items-center justify-end gap-3"
+              >
+                <Skeleton variant="chart" className={bar.labelClassName} />
+                <Skeleton variant="chart" className={bar.barClassName} />
+              </div>
+            ))}
           </div>
         </div>
-        <Skeleton className="mx-6 h-14 rounded-xl bg-teal-100/60" />
+
+        <div className="mt-2 grid grid-cols-2 px-6">
+          {Array.from({ length: 2 }).map((_, index) => (
+            <div key={index} className="flex justify-center">
+              <Skeleton variant="chart" className="h-4 w-12" />
+            </div>
+          ))}
+        </div>
       </div>
     );
   }

--- a/app/statistics/_components/comparison-insight/comparison-insight.tsx
+++ b/app/statistics/_components/comparison-insight/comparison-insight.tsx
@@ -18,8 +18,8 @@ export default function ComparisonInsight({
   if (isLoading) {
     return (
       <div className="flex flex-col items-start px-6 py-6 w-full gap-2">
-        <Skeleton className="h-7 w-40 rounded-md bg-brand-primary/20" />
-        <Skeleton className="h-5 w-60 rounded-md bg-brand-primary/20" />
+        <Skeleton className="h-7 w-40 rounded-md" />
+        <Skeleton className="h-5 w-60 rounded-md" />
       </div>
     );
   }

--- a/app/statistics/_components/empty-statistics-preview.tsx
+++ b/app/statistics/_components/empty-statistics-preview.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { EMPTY_STATE_PREVIEW_STATISTICS } from "@/app/utils/empty-state-preview";
+import ComparisonChart from "./comparison-chart";
+import ComparisonInsight from "./comparison-insight";
+
+interface Props {
+  userName: string;
+}
+
+export default function EmptyStatisticsPreview({ userName }: Props) {
+  const displayUserName = userName || "사용자";
+
+  return (
+    <div
+      className="h-full w-full overflow-hidden animate-in fade-in duration-500 pointer-events-none"
+      aria-hidden="true"
+    >
+      <div className="mt-4">
+        <ComparisonInsight
+          title={EMPTY_STATE_PREVIEW_STATISTICS.ageBand.title}
+          diffAmount={EMPTY_STATE_PREVIEW_STATISTICS.ageBand.diffAmount}
+          status={EMPTY_STATE_PREVIEW_STATISTICS.ageBand.status}
+        />
+
+        <ComparisonChart
+          userName={`${displayUserName}님`}
+          userAmount={EMPTY_STATE_PREVIEW_STATISTICS.ageBand.userAmount}
+          compareName={EMPTY_STATE_PREVIEW_STATISTICS.ageBand.compareName}
+          compareAmount={EMPTY_STATE_PREVIEW_STATISTICS.ageBand.compareAmount}
+        />
+      </div>
+
+      <div className="mt-10">
+        <ComparisonInsight
+          title={EMPTY_STATE_PREVIEW_STATISTICS.service.title}
+          diffAmount={EMPTY_STATE_PREVIEW_STATISTICS.service.diffAmount}
+          status={EMPTY_STATE_PREVIEW_STATISTICS.service.status}
+        />
+
+        <ComparisonChart
+          userName={EMPTY_STATE_PREVIEW_STATISTICS.service.userName}
+          userAmount={EMPTY_STATE_PREVIEW_STATISTICS.service.userAmount}
+          compareName={EMPTY_STATE_PREVIEW_STATISTICS.service.compareName}
+          compareAmount={EMPTY_STATE_PREVIEW_STATISTICS.service.compareAmount}
+        />
+      </div>
+    </div>
+  );
+}

--- a/app/statistics/_components/empty-subscription-overlay/empty-subscription-overlay.tsx
+++ b/app/statistics/_components/empty-subscription-overlay/empty-subscription-overlay.tsx
@@ -1,49 +1,19 @@
 "use client";
 
-import { useEffect } from "react";
-import Link from "next/link";
-import { useSupabase } from "@/hooks/useSupabase";
-
 export default function EmptySubscriptionOverlay() {
-  const { session } = useSupabase();
-  const isLoggedIn = Boolean(session?.user);
-
-  useEffect(() => {
-    const previousOverflow = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
-    return () => {
-      document.body.style.overflow = previousOverflow;
-    };
-  }, []);
-
   return (
-    <div className="absolute inset-0 z-40 flex flex-col items-center justify-center bg-white/70 backdrop-blur-xs px-6">
-      <div className="text-center mb-10">
-        <h2 className="text-xl font-bold text-black mb-2">
-          구독 서비스를 추가하세요
-        </h2>
-        <p className="body-lg text-gray-500 leading-relaxed">
-          추가된 구독 서비스가 없어
-          <br />
-          <span className="font-bold text-gray-300">
+    <div className="absolute inset-0 z-40 bg-white/70 backdrop-blur-xs">
+      <div className="flex h-full flex-col px-6">
+        <div className="flex flex-1 flex-col gap-2 items-center justify-center text-center">
+          <h2 className="text-xl font-bold text-black">
+            구독 서비스를 추가하세요
+          </h2>
+          <p className="body-lg text-gray-300">
+            추가된 구독 서비스가 없어
+            <br />
             지금은 통계를 낼 수 없어요
-          </span>
-        </p>
-      </div>
-
-      <div className="w-full max-w-sm">
-        {isLoggedIn ? (
-          <Link href="/subscription/add" className="btn btn-primary btn-lg">
-            구독 추가하기
-          </Link>
-        ) : (
-          <Link
-            href="/login?redirect=/subscription/add"
-            className="btn btn-primary btn-lg"
-          >
-            로그인하고 구독 추가하기
-          </Link>
-        )}
+          </p>
+        </div>
       </div>
     </div>
   );

--- a/app/statistics/statistics-page-client.tsx
+++ b/app/statistics/statistics-page-client.tsx
@@ -1,19 +1,24 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
+import { cn } from "@/lib/utils";
 
 import AIAnalysisBanner from "./_components/ai-analysis-banner/ai-analysis-banner";
 import Header from "@/app/components/header";
 import BottomNav from "@/app/components/bottom-nav";
+import BottomCTA from "@/app/components/bottom-cta";
 import MonthExpenseSelector from "./_components/month-expense-selector";
 import AgeBandSection from "./_components/age-band-section";
 import ServiceComparisonSection from "./_components/service-comparison-section";
 import EmptyAnalysis from "./_components/empty-analysis";
 import EmptySubscriptionOverlay from "./_components/empty-subscription-overlay";
+import EmptyStatisticsPreview from "./_components/empty-statistics-preview";
 import AnalysisSummary, {
   type AnalysisSummaryItem,
 } from "./_components/analysis-summary/analysis-summary";
 import ErrorScreen from "@/app/components/error-screen/error-screen";
+import { EMPTY_STATE_PREVIEW_SUBSCRIPTION_TOTAL } from "@/app/utils/empty-state-preview";
 
 import { calculateMonthlyTotal } from "@/app/utils/subscriptions/calculate";
 import { useCurrentUserQuery, useUserProfileQuery } from "@/query/users";
@@ -32,6 +37,7 @@ export default function StatisticsPageClient() {
   const rawNickname = profile?.nickname || user?.user_metadata?.nickname;
   const userName =
     isUserLoading || isProfileLoading ? "" : rawNickname || "사용자";
+  const isLoggedIn = Boolean(user);
 
   const isUserResolved = user !== undefined && !isUserLoading;
 
@@ -61,28 +67,48 @@ export default function StatisticsPageClient() {
     !isSubscriptionsLoading &&
     !isAllEmpty &&
     monthlyTotalAmount === 0;
-  const displayAmount = isAllEmpty || isMonthlyEmpty ? 0 : monthlyTotalAmount;
+  const displayAmount = isAllEmpty
+    ? EMPTY_STATE_PREVIEW_SUBSCRIPTION_TOTAL
+    : isMonthlyEmpty
+      ? 0
+      : monthlyTotalAmount;
 
   return (
-    <>
+    <div className={cn(isAllEmpty && "flex h-dvh flex-col overflow-hidden")}>
       <main
-        className={`relative flex min-h-screen w-full flex-col bg-white ${
-          isAllEmpty ? "h-screen overflow-hidden" : ""
-        }`}
+        className={cn(
+          "relative flex w-full flex-col bg-white",
+          isAllEmpty ? "min-h-0 flex-1 overflow-hidden" : "min-h-screen"
+        )}
       >
         <Header variant="text" leftText="통계" hasNotification />
 
-        <div className="flex w-full flex-1 flex-col pb-32">
+        <div
+          className={cn(
+            "flex w-full flex-1 min-h-0 flex-col",
+            isAllEmpty ? "overflow-hidden" : "pb-32"
+          )}
+        >
           <AIAnalysisBanner isAllEmpty={isAllEmpty} />
 
-          <div className="relative flex flex-1 flex-col">
+          <div
+            className={cn(
+              "relative flex flex-1 min-h-0 flex-col",
+              isAllEmpty && "overflow-hidden"
+            )}
+          >
             <MonthExpenseSelector
               selectedDate={selectedDate}
               groupCount={displayAmount}
               onChangeDate={setSelectedDate}
             />
 
-            <div className="relative flex-1 w-full">
+            <div
+              className={cn(
+                "relative flex-1 min-h-0 w-full",
+                isAllEmpty && "overflow-hidden"
+              )}
+            >
               {isError && (
                 <ErrorScreen
                   error={new Error("데이터를 불러오는 중 문제가 발생했어요.")}
@@ -108,24 +134,43 @@ export default function StatisticsPageClient() {
 
                   {analysisSummaryItems.length > 0 && (
                     <div className="mt-10 border-t-8 border-gray-50">
-                      <AnalysisSummary
-                        hasData
-                        items={analysisSummaryItems}
-                      />
+                      <AnalysisSummary hasData items={analysisSummaryItems} />
                     </div>
                   )}
                 </div>
               )}
 
               {!isAllEmpty && isMonthlyEmpty && <EmptyAnalysis />}
+
+              {isAllEmpty && <EmptyStatisticsPreview userName={userName} />}
             </div>
 
             {isAllEmpty && <EmptySubscriptionOverlay />}
           </div>
+
+          {isAllEmpty && (
+            <BottomCTA hasBottomNav className="bg-transparent">
+              {isLoggedIn ? (
+                <Link
+                  href="/subscription/add"
+                  className="btn btn-primary btn-lg"
+                >
+                  구독 추가하기
+                </Link>
+              ) : (
+                <Link
+                  href="/login?redirect=/subscription/add"
+                  className="btn btn-primary btn-lg"
+                >
+                  로그인 하기
+                </Link>
+              )}
+            </BottomCTA>
+          )}
         </div>
       </main>
 
       <BottomNav />
-    </>
+    </div>
   );
 }

--- a/app/subscription/[id]/loading.tsx
+++ b/app/subscription/[id]/loading.tsx
@@ -6,18 +6,18 @@ export default function Loading() {
       <div className="w-full mt-5 px-6 flex flex-col gap-5">
         {/* SubscriptionList skeleton */}
         <div className="w-full flex justify-center items-center gap-3">
-          <Skeleton className="min-w-12 min-h-12 w-12 h-12 rounded-md bg-brand-primary/20" />
+          <Skeleton className="min-w-12 min-h-12 w-12 h-12 rounded-md" />
           <div className="w-full flex flex-col gap-1">
-            <Skeleton className="w-1/2 h-6 rounded-md bg-brand-primary/20" />
-            <Skeleton className="w-1/4 h-4 rounded-md bg-brand-primary/20" />
+            <Skeleton className="w-1/2 h-6 rounded-md" />
+            <Skeleton className="w-1/4 h-4 rounded-md" />
           </div>
         </div>
 
-        <Skeleton className="w-full h-49 rounded-md bg-brand-primary/20" />
+        <Skeleton className="w-full h-49 rounded-md" />
 
         <div className="w-full flex flex-col gap-1">
-          <Skeleton className="w-full h-8 rounded-md bg-brand-primary/20" />
-          <Skeleton className="w-full h-8 rounded-md bg-brand-primary/20" />
+          <Skeleton className="w-full h-8 rounded-md" />
+          <Skeleton className="w-full h-8 rounded-md" />
         </div>
       </div>
     </>

--- a/app/utils/empty-state-preview.ts
+++ b/app/utils/empty-state-preview.ts
@@ -1,0 +1,59 @@
+import type { SubscriptableBrandType } from "@/app/utils/brand/type";
+
+export type EmptyStatePreviewSubscription = {
+  brandType: SubscriptableBrandType;
+  price: number;
+  billingCycle: "monthly" | "yearly";
+  group?: boolean;
+  groupCount?: number;
+  isFreeTrial?: boolean;
+};
+
+export const EMPTY_STATE_PREVIEW_SUBSCRIPTIONS: EmptyStatePreviewSubscription[] =
+  [
+    {
+      brandType: "netflix",
+      price: 17000,
+      billingCycle: "monthly",
+    },
+    {
+      brandType: "youtube-premium",
+      price: 14900,
+      billingCycle: "monthly",
+    },
+    {
+      brandType: "wavve",
+      price: 3300,
+      billingCycle: "monthly",
+    },
+    {
+      brandType: "nintendo-family",
+      price: 8750,
+      billingCycle: "monthly",
+      group: true,
+      groupCount: 4,
+    },
+  ];
+
+export const EMPTY_STATE_PREVIEW_SUBSCRIPTION_TOTAL =
+  EMPTY_STATE_PREVIEW_SUBSCRIPTIONS.reduce((sum, item) => sum + item.price, 0);
+
+export const EMPTY_STATE_PREVIEW_STATISTICS = {
+  ageBand: {
+    title: "20대 평균 소비와 비교",
+    diffAmount: 5400,
+    status: "under" as const,
+    userAmount: 15200,
+    compareName: "20대 평균",
+    compareAmount: 20600,
+  },
+  service: {
+    title: "넷플릭스 유저 평균 소비와 비교",
+    diffAmount: 4300,
+    status: "over" as const,
+    userName: "넷플릭스",
+    userAmount: 17000,
+    compareName: "넷플릭스 평균 소비",
+    compareAmount: 12700,
+  },
+};

--- a/components/ui/skeleton.tsx
+++ b/components/ui/skeleton.tsx
@@ -1,12 +1,22 @@
 import { cn } from "@/lib/utils";
 
+interface SkeletonProps extends React.HTMLAttributes<HTMLDivElement> {
+  variant?: "default" | "chart";
+}
+
 function Skeleton({
   className,
+  variant = "default",
   ...props
-}: React.HTMLAttributes<HTMLDivElement>) {
+}: SkeletonProps) {
   return (
     <div
-      className={cn("animate-pulse rounded-md bg-gray-100", className)}
+      className={cn(
+        "animate-pulse rounded-md",
+        variant === "default" && "bg-gray-100",
+        variant === "chart" && "bg-gray-200/70",
+        className
+      )}
       {...props}
     />
   );


### PR DESCRIPTION
## 📋 개요

구독이 없는 빈 화면에서 목데이터로 미리보기 화면을 보여주도록 홈/통계 화면을 개선하고,
스켈레톤 컴포넌트 스타일을 공통화했습니다.

## 🔗 관련 이슈

- Closes #113

## 📝 변경 사항

- `empty-state-preview.ts` 추가 — 홈/통계 빈 화면용 목데이터 상수 분리
- `EmptyStatisticsPreview` 컴포넌트 추가 — 구독 없을 때 통계 프리뷰 표시
- 홈 구독 섹션 — 구독 없을 때 목데이터 리스트로 화면 채우고 블러 오버레이 처리
- 통계 페이지 — 구독 없을 때 목데이터 차트 프리뷰 + 로그인 여부에 따른 CTA 분기
- `EmptySubscriptionOverlay` 단순화 — `document.body.overflow` 직접 조작 제거, CTA 로직을 상위 컴포넌트로 이동
- `SubscriptionList` — `href` 없을 때 `<Link>` 대신 `<div>` 렌더링으로 접근성 개선
- `Skeleton` 컴포넌트 — `variant` prop 추가(`default` | `chart`), 하드코딩된 색상/애니메이션 제거
- `BottomCTA` — `env(safe-area-inset-bottom)` 적용, 미사용 `reserveSpace` prop 제거
- z-index 레이어 정리 — BottomCTA `z-40`, BottomNav `z-40`, 오버레이 `z-30` (모달 `z-50` 아래로 정렬)

## 🖼️ 스크린샷 (UI 변경 시)

> DB없을때 목데이터가 나오게 수정했어요
<img width="1482" height="1162" alt="스크린샷 2026-05-21 오후 3 21 07" src="https://github.com/user-attachments/assets/f83a55e5-72b7-40bb-bf40-c48047c6ed0d" />
<img width="1482" height="1162" alt="스크린샷 2026-05-21 오후 3 21 04" src="https://github.com/user-attachments/assets/a4213218-b32a-44f1-947b-601277172cca" />

> 구독추가 폼에서 CTA버튼때문에 콘텐츠가 가려지지 않아요
<img width="1482" height="1162" alt="스크린샷 2026-05-21 오후 3 20 59" src="https://github.com/user-attachments/assets/2da4f28e-e581-4114-9f11-4ee72bf3aa3e" />


## ✅ 체크리스트

- [ ] 로컬에서 동작 확인했습니다
- [ ] (필요시) 테스트를 추가/수정했습니다
- [ ] 문서를 업데이트했습니다 (필요시)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 구독 미보유 사용자를 위한 빈 상태 미리보기 기능 추가

* **개선사항**
  * 로딩 화면의 스켈레톤 UI 스타일 개선
  * 통계 페이지의 레이아웃 및 차트 표시 최적화
  * 하단 네비게이션 및 CTA 버튼의 배치 개선
  * 구독 폼과 리스트의 표시 방식 개선

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Leemainsw/detox/pull/117?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->